### PR TITLE
Fix vm module creation from flatbuffer.

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -410,10 +410,10 @@ def run_iree(use_gpu, model_names, model_class, precision, num_threads,
     #flatbuffer_blob = compile_str(compiler_module, target_backends=[backend])
 
     # Save module as MLIR file in a directory
-    vm_module = ireert.VmModule.from_flatbuffer(flatbuffer_blob)
+    config = ireert.Config(backend_config)
+    vm_module = ireert.VmModule.from_flatbuffer(config.vm_instance, flatbuffer_blob)
     #tracer = ireert.Tracer(os.getcwd())
     # TODO: Remove printing of "Tracing module.predict"
-    config = ireert.Config(backend_config)
     ctx = ireert.SystemContext(config=config)
     ctx.add_vm_module(vm_module)
     BertCompiled = ctx.modules.module


### PR DESCRIPTION
Adds a passing of config.vm_instance as the first argument of VmModule.from_flatbuffer() call.